### PR TITLE
fix Dockerfile: copy JAR to known filename to avoid glob expansion issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 # Copy local code to the container image
 COPY . ./
 
-# Build the app
-RUN ./gradlew clean build -x test
+# Build the app and rename JAR to a known filename
+RUN ./gradlew clean build -x test && cp build/libs/*.jar app.jar
 
-# Run the app by dynamically finding the JAR file in the build/libs directory
-CMD ["sh", "-c", "java -Dspring.profiles.active=prod -jar build/libs/*.jar"]
+# Run the app
+CMD ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]


### PR DESCRIPTION
PR for issue #5